### PR TITLE
hotfix(:wrench:) Fixed sdk-js example central logger config

### DIFF
--- a/examples/sdk-js.example.js
+++ b/examples/sdk-js.example.js
@@ -5,7 +5,7 @@ const config = new Coralogix.LoggerConfig({
     privateKey:"9626c7dd-8174-5015-a3fe-5572e042b6d9",
 });
 
-Coralogix.CoralogixLogger.configure(config);
+Coralogix.CoralogixCentralLogger.configure(config);
 
 // create a new logger with category
 const centralLogger = new Coralogix.CoralogixCentralLogger();


### PR DESCRIPTION
Coralogix configure must be initiated by the logger class instance. The SDK JS sample is using the `CoralogixCentralLogger` class as a logger, therefore it should use the `CoralogixCentralLogger.configure()` API to set configuration.