### PR TITLE
fix: move authorization to HTTP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.0](https://github.com/coralogix/nodejs-coralogix-sdk/compare/v1.1.34...v1.2.0) (2025-10-23)
+
 ### [1.1.34](https://github.com/coralogix/nodejs-coralogix-sdk/compare/v1.1.33...v1.1.34) (2025-10-15)
 
 ### [1.1.33](https://github.com/coralogix/nodejs-coralogix-sdk/compare/v1.1.31...v1.1.33) (2025-10-15)

--- a/dist/entities/bulk.d.ts
+++ b/dist/entities/bulk.d.ts
@@ -29,13 +29,6 @@ export declare class Bulk {
      */
     static bulkFromConfig(config: LoggerConfig): Bulk;
     /**
-     * @member {string} privateKey
-     * @memberOf Bulk
-     * @description Coralogix private key
-     * @public
-     */
-    privateKey: string;
-    /**
      * @member {string} applicationName
      * @memberOf Bulk
      * @description Application name

--- a/dist/entities/bulk.js
+++ b/dist/entities/bulk.js
@@ -66,7 +66,6 @@ var Bulk = /** @class */ (function () {
      */
     Bulk.bulkFromConfig = function (config) {
         var bulk = new Bulk();
-        bulk.privateKey = config.privateKey || constants_1.Constants.FAILED_PRIVATE_KEY;
         bulk.applicationName = config.applicationName || constants_1.Constants.NO_APP_NAME;
         bulk.subsystemName = config.subsystemName || constants_1.Constants.NO_SUB_SYSTEM;
         bulk.computerName = config.computerName || bulk.computerName;

--- a/dist/http.service.js
+++ b/dist/http.service.js
@@ -34,6 +34,10 @@ var HttpHelper;
         var options = {
             decompress: true,
             timeout: constants_1.Constants.HTTP_TIMEOUT,
+            headers: {
+                'Authorization': "Bearer ".concat(config.privateKey),
+                'Content-Type': 'application/json'
+            }
         };
         if (config.proxyUri) {
             options.proxy = config.proxyUri;

--- a/dist/version.d.ts
+++ b/dist/version.d.ts
@@ -1,1 +1,1 @@
-export declare const SDK_VERSION = "1.1.34";
+export declare const SDK_VERSION = "1.2.0";

--- a/dist/version.d.ts
+++ b/dist/version.d.ts
@@ -1,1 +1,1 @@
-export declare const SDK_VERSION = "1.1.29";
+export declare const SDK_VERSION = "1.1.34";

--- a/dist/version.js
+++ b/dist/version.js
@@ -1,4 +1,4 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SDK_VERSION = void 0;
-exports.SDK_VERSION = '1.1.34';
+exports.SDK_VERSION = '1.2.0';

--- a/dist/version.js
+++ b/dist/version.js
@@ -1,4 +1,4 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SDK_VERSION = void 0;
-exports.SDK_VERSION = '1.1.29';
+exports.SDK_VERSION = '1.1.34';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-logger",
   "title": "Coralogix Node.js SDK",
-  "version": "1.1.34",
+  "version": "1.2.0",
   "description": "Node.js SDK to send your logs to Coralogix",
   "homepage": "https://coralogix.com/",
   "license": "Apache-2.0",

--- a/src/entities/bulk.ts
+++ b/src/entities/bulk.ts
@@ -33,20 +33,12 @@ export class Bulk {
      */
     public static bulkFromConfig(config: LoggerConfig): Bulk {
         const bulk = new Bulk();
-        bulk.privateKey = config.privateKey || Constants.FAILED_PRIVATE_KEY;
         bulk.applicationName = config.applicationName || Constants.NO_APP_NAME;
         bulk.subsystemName = config.subsystemName || Constants.NO_SUB_SYSTEM;
         bulk.computerName = config.computerName || bulk.computerName;
         return bulk;
     }
 
-    /**
-     * @member {string} privateKey
-     * @memberOf Bulk
-     * @description Coralogix private key
-     * @public
-     */
-    public privateKey: string;
 
     /**
      * @member {string} applicationName

--- a/src/http.service.ts
+++ b/src/http.service.ts
@@ -33,6 +33,10 @@ export namespace HttpHelper {
         const options: AxiosRequestConfig = {
             decompress: true,
             timeout: Constants.HTTP_TIMEOUT,
+            headers: {
+                'Authorization': `Bearer ${config.privateKey}`,
+                'Content-Type': 'application/json'
+            }
         };
         if (config.proxyUri) {
             options.proxy = config.proxyUri;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = '1.1.34';
+export const SDK_VERSION = '1.2.0';

--- a/test/entries/bulk.js
+++ b/test/entries/bulk.js
@@ -18,81 +18,58 @@ describe('Bulk', function () {
 
     describe('#bulkFromConfig()', function () {
         it('should fill bulk with user values', function () {
-            var privateKey = '*************';
             var applicationName = 'NodeJS test';
             var subsystemName = 'Test subsystem';
             var computerName = 'Test host';
 
             var bulk = bulk_entry.Bulk.bulkFromConfig({
-                privateKey: privateKey,
+                privateKey: 'test-key',
                 applicationName: applicationName,
                 subsystemName: subsystemName,
                 computerName: computerName
             });
 
-            assert.equal(bulk.privateKey, privateKey);
             assert.equal(bulk.applicationName, applicationName);
             assert.equal(bulk.subsystemName, subsystemName);
             assert.equal(bulk.computerName, computerName);
         });
 
-        it('should fill bulk with default private key', function () {
-            var applicationName = 'NodeJS test';
+        it('should fill bulk with default application name when null', function () {
             var subsystemName = 'Test subsystem';
 
             var bulk = bulk_entry.Bulk.bulkFromConfig({
-                privateKey: null,
-                applicationName: applicationName,
-                subsystemName: subsystemName
-            });
-
-            assert.equal(bulk.privateKey, constants.Constants.FAILED_PRIVATE_KEY);
-            assert.equal(bulk.applicationName, applicationName);
-            assert.equal(bulk.subsystemName, subsystemName);
-        });
-
-        it('should fill bulk with default application name', function () {
-            var privateKey = '*************';
-            var subsystemName = 'Test subsystem';
-
-            var bulk = bulk_entry.Bulk.bulkFromConfig({
-                privateKey: privateKey,
+                privateKey: 'test-key',
                 applicationName: null,
                 subsystemName: subsystemName
             });
 
-            assert.equal(bulk.privateKey, privateKey);
             assert.equal(bulk.applicationName, constants.Constants.NO_APP_NAME);
             assert.equal(bulk.subsystemName, subsystemName);
         });
 
-        it('should fill bulk with default subsystem name', function () {
-            var privateKey = '*************';
+        it('should fill bulk with default subsystem name when null', function () {
             var applicationName = 'NodeJS test';
 
             var bulk = bulk_entry.Bulk.bulkFromConfig({
-                privateKey: privateKey,
+                privateKey: 'test-key',
                 applicationName: applicationName,
                 subsystemName: null
             });
 
-            assert.equal(bulk.privateKey, privateKey);
             assert.equal(bulk.applicationName, applicationName);
             assert.equal(bulk.subsystemName, constants.Constants.NO_SUB_SYSTEM);
         });
 
         it('should fill bulk with default computer name', function () {
-            var privateKey = '*************';
             var applicationName = 'NodeJS test';
             var subsystemName = 'Test subsystem';
 
             var bulk = bulk_entry.Bulk.bulkFromConfig({
-                privateKey: privateKey,
+                privateKey: 'test-key',
                 applicationName: applicationName,
                 subsystemName: subsystemName
             });
 
-            assert.equal(bulk.privateKey, privateKey);
             assert.equal(bulk.applicationName, applicationName);
             assert.equal(bulk.subsystemName, subsystemName);
             assert.equal(bulk.computerName, ip_helper.IPHelper.getComputerName());


### PR DESCRIPTION
fixes CDS-2490 by moving API Key authorization from request body to HTTP header `Authorization: Bearer PRIVATE_KEY`